### PR TITLE
Pass options to tmux through an enviroment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Or standalone. Here's a oneliner.
 ```shell
 $ wget https://raw.githubusercontent.com/tonchis/tmuxify/master/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
 ```
+You can pass options to tmux with the `TMUX_OPTS` environment variable if you need.
 
 ### Why?
 

--- a/bin/tmuxify
+++ b/bin/tmuxify
@@ -9,7 +9,7 @@ fi
 
 session=${1:-$(basename $(pwd))}
 
-tmux new-session -s $session -d
+tmux $TMUX_OPTS new-session -s $session -d
 
 while read window pane command; do
   pane_number=${pane//[^0-9]*}
@@ -44,4 +44,4 @@ tmux select-window -t $session:$active_window
 
 tmux select-pane -t $session:$active_window.$active_pane
 
-tmux attach-session -t $session
+tmux $TMUX_OPTS attach-session -t $session

--- a/bin/tmuxify
+++ b/bin/tmuxify
@@ -9,7 +9,12 @@ fi
 
 session=${1:-$(basename $PWD | tr . -)}
 
-tmux $TMUX_OPTS new-session -s $session -d
+if [[ -z $(tmux ls 2>/dev/null | grep "$session") ]]; then
+  tmux $TMUX_OPTS new-session -s $session -d
+else
+  tmux $TMUX_OPTS attach -t $session
+  exit 0
+fi
 
 while read window pane command; do
   pane_number=${pane//[^0-9]*}

--- a/bin/tmuxify
+++ b/bin/tmuxify
@@ -7,7 +7,7 @@ if [[ ! -f $layout ]]; then
   exit 1
 fi
 
-session=${1:-$(basename $(pwd))}
+session=${1:-$(basename $PWD | tr . -)}
 
 tmux $TMUX_OPTS new-session -s $session -d
 


### PR DESCRIPTION
This PR enable passing option parameters to tmux with a TMUX_OPTS environment variable. 

**Motivation**
When you're running a linux machine if you use vim with a fancy color scheme like molokai, it's a known problem that you need to tell tmux to assume that the terminal it's running in supports 256 colors. I solve this passing the -2 flag when tmux creates or attach a session.
