### PR TITLE
Kill first window, whatever base index is set in .tmux.conf

### DIFF
--- a/bin/tmuxify
+++ b/bin/tmuxify
@@ -45,7 +45,8 @@ done < $layout
 #
 #   set-option -g renumber-windows on
 #
-tmux kill-window -t $session:1
+
+tmux kill-window -t $session:$( tmux list-windows -t $session -F "#{window_index}" | head -n 1 )
 
 tmux select-window -t $session:$active_window
 


### PR DESCRIPTION
We list windows and print index and take the first one to kill.
This closes #4 
