### PR TITLE
Latest release install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ brew tap tonchis/goodies && brew install tmuxify
 Or standalone. Here's a oneliner.
 
 ```shell
-$ wget https://raw.githubusercontent.com/tonchis/tmuxify/v1.2.0/bin/tmuxify/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
+$ wget https://raw.githubusercontent.com/tonchis/tmuxify/v1.2.0/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
 ```
 You can pass options to tmux with the `TMUX_OPTS` environment variable if you need.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ brew tap tonchis/goodies && brew install tmuxify
 Or standalone. Here's a oneliner.
 
 ```shell
-$ wget https://raw.githubusercontent.com/pote/tmuxify/v1.2.0/bin/tmuxify/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
+$ wget https://raw.githubusercontent.com/tonchis/tmuxify/v1.2.0/bin/tmuxify/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
 ```
 You can pass options to tmux with the `TMUX_OPTS` environment variable if you need.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ brew tap tonchis/goodies && brew install tmuxify
 Or standalone. Here's a oneliner.
 
 ```shell
-$ wget https://raw.githubusercontent.com/tonchis/tmuxify/master/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
+$ wget https://raw.githubusercontent.com/pote/tmuxify/v1.2.0/bin/tmuxify/bin/tmuxify && chmod +x tmuxify && sudo mv tmuxify /usr/local/bin
 ```
 You can pass options to tmux with the `TMUX_OPTS` environment variable if you need.
 


### PR DESCRIPTION
It's usually safer to have installation instructions for the latest stable release rather than bleeding edge, came into the issue while installing tmuxify on a new machine. :)
